### PR TITLE
Use `pyarrow.ffi` to allocate intermediate C structures

### DIFF
--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -18,7 +18,7 @@ if not rarrow.__version__.startswith(TARGET_VERSION):
 # In arrow >= 7.0.0, pointers can be passed as externalptr,
 # bit64::integer64(), or string, all of which prevent possible
 # problems with the previous versions which required a double().
-_use_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')
+_use_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
 
 def _rarrow_ptr(ptr_value):
     global _use_ptr_string

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -11,7 +11,9 @@ rarrow = packages.importr('arrow')
 
 
 # make sure a version is installed with the C API
-_rarrow_has_c_api = rinterface.evalr('packageVersion("arrow") >= "5.0.0"')[0]
+_rarrow_has_c_api = rinterface.evalr("""
+utils::packageVersion("arrow") >= base::package_version("5.0.0")
+""")[0]
 if not _rarrow_has_c_api:
     raise ValueError("rpy2_arrow requires R 'arrow' package version >= 5.0.0")
 
@@ -19,16 +21,18 @@ if not _rarrow_has_c_api:
 # In arrow >= 7.0.0, pointers can be passed as externalptr,
 # bit64::integer64(), or string, all of which prevent possible
 # problems with the previous versions which required a double().
-_use_r_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
+_use_r_ptr_string = rinterface.evalr("""
+utils::packageVersion("arrow") >= base::package_version("6.0.1.9000")
+""")[0]
 
 
 def _rarrow_ptr(ptr):
-    ptr_value = int(ffi.cast("uintptr_t", ptr))
+    ptr_value = int(ffi.cast('uintptr_t', ptr))
     return str(ptr_value) if _use_r_ptr_string else float(ptr_value)
 
 
 def _pyarrow_ptr(ptr):
-    return int(ffi.cast("uintptr_t", ptr))
+    return int(ffi.cast('uintptr_t', ptr))
 
 
 def pyarrow_to_r_array(
@@ -40,11 +44,11 @@ def pyarrow_to_r_array(
     The returned object depends on the active conversion rule in
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
-    array_ptr = ffi.new("struct ArrowArray*")
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new('struct ArrowArray*')
+    schema_ptr = ffi.new('struct ArrowSchema*')
 
     obj._export_to_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
-    return rarrow.Array["import_from_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    return rarrow.Array['import_from_c'](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_array(
@@ -54,10 +58,10 @@ def rarrow_to_py_array(
 
     This is sharing the C/C++ object between the two languages.
     """
-    array_ptr = ffi.new("struct ArrowArray*")
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new('struct ArrowArray*')
+    schema_ptr = ffi.new('struct ArrowSchema*')
 
-    obj["export_to_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    obj['export_to_c'](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
     return pyarrow.lib.Array._import_from_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
 
 
@@ -70,11 +74,11 @@ def pyarrow_to_r_recordbatch(
     The returned object depends on the active conversion rule in
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
-    array_ptr = ffi.new("struct ArrowArray*")
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new('struct ArrowArray*')
+    schema_ptr = ffi.new('struct ArrowSchema*')
 
     obj._export_to_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
-    return rarrow.RecordBatch["import_from_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    return rarrow.RecordBatch['import_from_c'](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_recordbatch(
@@ -84,10 +88,10 @@ def rarrow_to_py_recordbatch(
 
     This is sharing the C/C++ object between the two languages.
     """
-    array_ptr = ffi.new("struct ArrowArray*")
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new('struct ArrowArray*')
+    schema_ptr = ffi.new('struct ArrowSchema*')
 
-    obj["export_to_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    obj['export_to_c'](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
     return pyarrow.lib.RecordBatch._import_from_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
 
 
@@ -101,9 +105,9 @@ def pyarrow_to_r_recordbatchreader(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
 
-    stream_ptr = ffi.new("struct ArrowArrayStream*")
+    stream_ptr = ffi.new('struct ArrowArrayStream*')
     obj._export_to_c(_pyarrow_ptr(stream_ptr))
-    return rarrow.RecordBatchReader["import_from_c"](_rarrow_ptr(stream_ptr))
+    return rarrow.RecordBatchReader['import_from_c'](_rarrow_ptr(stream_ptr))
 
 
 def rarrow_to_py_recordbatchreader(
@@ -116,8 +120,8 @@ def rarrow_to_py_recordbatchreader(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
 
-    stream_ptr = ffi.new("struct ArrowArrayStream*")
-    obj["export_to_c"](_rarrow_ptr(stream_ptr))
+    stream_ptr = ffi.new('struct ArrowArrayStream*')
+    obj['export_to_c'](_rarrow_ptr(stream_ptr))
     return pyarrow.lib.RecordBatchReader._import_from_c(_pyarrow_ptr(stream_ptr))
 
 
@@ -149,9 +153,9 @@ def rarrow_to_py_chunkedarray(
 def pyarrow_to_r_datatype(
         obj: 'pyarrow.lib.DataType'
 ):
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    schema_ptr = ffi.new('struct ArrowSchema*')
     obj._export_to_c(_pyarrow_ptr(schema_ptr))
-    return rarrow.DataType["import_from_c"](_rarrow_ptr(schema_ptr))
+    return rarrow.DataType['import_from_c'](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_datatype(
@@ -161,17 +165,17 @@ def rarrow_to_py_datatype(
 
     This is sharing the C/C++ object between the two languages.
     """
-    schema_ptr = ffi.new("struct ArrowSchema*")
-    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    schema_ptr = ffi.new('struct ArrowSchema*')
+    obj['export_to_c'](_rarrow_ptr(schema_ptr))
     return pyarrow.lib.DataType._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
 def pyarrow_to_r_field(
         obj: 'pyarrow.lib.Field'
 ):
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    schema_ptr = ffi.new('struct ArrowSchema*')
     obj._export_to_c(_pyarrow_ptr(schema_ptr))
-    return rarrow.Field["import_from_c"](_rarrow_ptr(schema_ptr))
+    return rarrow.Field['import_from_c'](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_field(
@@ -182,8 +186,8 @@ def rarrow_to_py_field(
     This is sharing the C/C++ object between the two languages.
     """
 
-    schema_ptr = ffi.new("struct ArrowSchema*")
-    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    schema_ptr = ffi.new('struct ArrowSchema*')
+    obj['export_to_c'](_rarrow_ptr(schema_ptr))
     return pyarrow.lib.Field._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
@@ -246,9 +250,9 @@ def pyarrow_to_r_schema(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
 
-    schema_ptr = ffi.new("struct ArrowSchema*")
+    schema_ptr = ffi.new('struct ArrowSchema*')
     obj._export_to_c(_pyarrow_ptr(schema_ptr))
-    return rarrow.Schema["import_from_c"](_rarrow_ptr(schema_ptr))
+    return rarrow.Schema['import_from_c'](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_schema(
@@ -261,8 +265,8 @@ def rarrow_to_py_schema(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
 
-    schema_ptr = ffi.new("struct ArrowSchema*")
-    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    schema_ptr = ffi.new('struct ArrowSchema*')
+    obj['export_to_c'](_rarrow_ptr(schema_ptr))
     return pyarrow.lib.Schema._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
@@ -294,10 +298,10 @@ converter._rpy2py_nc_map.update(
 converter._rpy2py_nc_map[rinterface.SexpEnvironment].update(
     {
         'Array': rarrow_to_py_array,
-        'RecordBatch': rarrow_to_py_recordbatch,
-        'RecordBatchReader': rarrow_to_py_recordbatchreader,
         'ChunkedArray': rarrow_to_py_chunkedarray,
         'Field': rarrow_to_py_field,
+        'RecordBatch': rarrow_to_py_recordbatch,
+        'RecordBatchReader': rarrow_to_py_recordbatchreader,
         'Schema': rarrow_to_py_schema,
         'Table': rarrow_to_py_table,
         'Type': rarrow_to_py_datatype

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -25,7 +25,7 @@ def pyarrow_to_r_array(
     The returned object depends on the active conversion rule in
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
-    array_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new("struct ArrowArray*")
     array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
@@ -41,7 +41,7 @@ def rarrow_to_py_array(
 
     This is sharing the C/C++ object between the two languages.
     """
-    array_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new("struct ArrowArray*")
     array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
@@ -59,7 +59,7 @@ def pyarrow_to_r_recordbatch(
     The returned object depends on the active conversion rule in
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
-    array_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new("struct ArrowArray*")
     array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
@@ -75,7 +75,7 @@ def rarrow_to_py_recordbatch(
 
     This is sharing the C/C++ object between the two languages.
     """
-    array_ptr = ffi.new("struct ArrowSchema*")
+    array_ptr = ffi.new("struct ArrowArray*")
     array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -11,7 +11,7 @@ rarrow = packages.importr('arrow')
 TARGET_VERSION = '6.0.'
 if not rarrow.__version__.startswith(TARGET_VERSION):
     warnings.warn(
-        'This was designed againt arrow versions starting with %s'
+        'This was designed against arrow versions starting with %s'
         ' but you have %s' %
         (TARGET_VERSION, rarrow.__version__))
 
@@ -103,7 +103,7 @@ def pyarrow_to_r_recordbatchreader(
 def rarrow_to_py_recordbatchreader(
         obj: robjects.Environment
 ):
-    """Create a pyarrow RecordBatchReader fomr an R `arrow::RecordBatchReader` object.
+    """Create a pyarrow RecordBatchReader from an R `arrow::RecordBatchReader` object.
 
     This is sharing the C/C++ object between the two languages.
     The returned object depends on the active conversion rule in
@@ -215,7 +215,7 @@ def rarrow_to_py_table(
         rpy2py: typing.Optional[
             conversion.Converter] = None
 ):
-    """Create a pyarrow Table fomr an R `arrow::Table` object.
+    """Create a pyarrow Table from an R `arrow::Table` object.
 
     This is sharing the C/C++ object between the two languages.
     The returned object depends on the active conversion rule in
@@ -254,7 +254,7 @@ def pyarrow_to_r_schema(
 def rarrow_to_py_schema(
         obj: robjects.Environment
 ):
-    """Create a pyarrow Schema fomr an R `arrow::Schema` object.
+    """Create a pyarrow Schema from an R `arrow::Schema` object.
 
     This is sharing the C/C++ object between the two languages.
     The returned object depends on the active conversion rule in

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -113,7 +113,7 @@ def rarrow_to_py_recordbatchreader(
     stream_ptr = ffi.new("struct ArrowArrayStream*")
     stream_ptr_value = int(ffi.cast("uintptr_t", stream_ptr))
     obj["export_to_c"](str(stream_ptr_value))
-    return pyarrow.lib.RecordBatchReader._import_from_c(int(stream_ptr_value))
+    return pyarrow.lib.RecordBatchReader._import_from_c(stream_ptr_value)
 
 
 def pyarrow_to_r_chunkedarray(

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -21,6 +21,7 @@ if not _rarrow_has_c_api:
 # problems with the previous versions which required a double().
 _use_r_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
 
+
 def _rarrow_ptr(ptr):
     ptr_value = int(ffi.cast("uintptr_t", ptr))
     return str(ptr_value) if _use_r_ptr_string else float(ptr_value)

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -15,6 +15,19 @@ if not rarrow.__version__.startswith(TARGET_VERSION):
         ' but you have %s' %
         (TARGET_VERSION, rarrow.__version__))
 
+# In arrow >= 7.0.0, pointers can be passed as externalptr,
+# bit64::integer64(), or string, all of which prevent possible
+# problems with the previous versions which required a double().
+_use_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')
+
+def _rarrow_ptr(ptr_value):
+    global _use_ptr_string
+
+    if _use_ptr_string:
+        return str(ptr_value)
+    else:
+        return float(ptr_value)
+
 
 def pyarrow_to_r_array(
         obj: 'pyarrow.lib.Array'
@@ -31,7 +44,7 @@ def pyarrow_to_r_array(
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
     
     obj._export_to_c(array_ptr_value, schema_ptr_value)
-    return rarrow.Array["import_from_c"](str(array_ptr_value), str(schema_ptr_value))
+    return rarrow.Array["import_from_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
 
 
 def rarrow_to_py_array(
@@ -46,7 +59,7 @@ def rarrow_to_py_array(
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
-    obj["export_to_c"](str(array_ptr_value), str(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
     return pyarrow.lib.Array._import_from_c(array_ptr_value, schema_ptr_value)
 
 
@@ -65,7 +78,7 @@ def pyarrow_to_r_recordbatch(
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
     obj._export_to_c(array_ptr_value, schema_ptr_value)
-    return rarrow.RecordBatch["import_from_c"](str(array_ptr_value), str(schema_ptr_value))
+    return rarrow.RecordBatch["import_from_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
 
 
 def rarrow_to_py_recordbatch(
@@ -80,7 +93,7 @@ def rarrow_to_py_recordbatch(
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
-    obj["export_to_c"](str(array_ptr_value), str(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
     return pyarrow.lib.RecordBatch._import_from_c(array_ptr_value, schema_ptr_value)
 
 
@@ -97,7 +110,7 @@ def pyarrow_to_r_recordbatchreader(
     stream_ptr = ffi.new("struct ArrowArrayStream*")
     stream_ptr_value = int(ffi.cast("uintptr_t", stream_ptr))
     obj._export_to_c(stream_ptr_value)
-    return rarrow.RecordBatchReader["import_from_c"](str(stream_ptr_value))
+    return rarrow.RecordBatchReader["import_from_c"](_rarrow_ptr(stream_ptr_value))
 
 
 def rarrow_to_py_recordbatchreader(
@@ -112,7 +125,7 @@ def rarrow_to_py_recordbatchreader(
 
     stream_ptr = ffi.new("struct ArrowArrayStream*")
     stream_ptr_value = int(ffi.cast("uintptr_t", stream_ptr))
-    obj["export_to_c"](str(stream_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(stream_ptr_value))
     return pyarrow.lib.RecordBatchReader._import_from_c(stream_ptr_value)
 
 
@@ -147,7 +160,7 @@ def pyarrow_to_r_datatype(
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
     obj._export_to_c(schema_ptr_value)
-    return rarrow.DataType["import_from_c"](str(schema_ptr_value))
+    return rarrow.DataType["import_from_c"](_rarrow_ptr(schema_ptr_value))
 
 
 def rarrow_to_py_datatype(
@@ -159,7 +172,7 @@ def rarrow_to_py_datatype(
     """
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](str(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
     return pyarrow.lib.DataType._import_from_c(int(schema_ptr_value))
 
 
@@ -169,7 +182,7 @@ def pyarrow_to_r_field(
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
     obj._export_to_c(schema_ptr_value)
-    return rarrow.Field["import_from_c"](str(schema_ptr_value))
+    return rarrow.Field["import_from_c"](_rarrow_ptr(schema_ptr_value))
 
 
 def rarrow_to_py_field(
@@ -182,7 +195,7 @@ def rarrow_to_py_field(
 
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](str(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
     return pyarrow.lib.Field._import_from_c(int(schema_ptr_value))
 
 
@@ -248,7 +261,7 @@ def pyarrow_to_r_schema(
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
     obj._export_to_c(schema_ptr_value)
-    return rarrow.Schema["import_from_c"](str(schema_ptr_value))
+    return rarrow.Schema["import_from_c"](_rarrow_ptr(schema_ptr_value))
 
 
 def rarrow_to_py_schema(
@@ -263,7 +276,7 @@ def rarrow_to_py_schema(
 
     schema_ptr = ffi.new("struct ArrowSchema*")
     schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](str(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
     return pyarrow.lib.Schema._import_from_c(int(schema_ptr_value))
 
 

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -10,6 +10,12 @@ import typing
 rarrow = packages.importr('arrow')
 
 
+# make sure a version is installed with the C API
+_rarrow_has_c_api = rinterface.evalr('packageVersion("arrow") >= "5.0.0"')[0]
+if not _rarrow_has_c_api:
+    raise ValueError("rpy2_arrow requires R 'arrow' package version >= 5.0.0")
+
+
 # In arrow >= 7.0.0, pointers can be passed as externalptr,
 # bit64::integer64(), or string, all of which prevent possible
 # problems with the previous versions which required a double().

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -11,7 +11,7 @@ rarrow = packages.importr('arrow')
 TARGET_VERSION = '6.0.'
 if not rarrow.__version__.startswith(TARGET_VERSION):
     warnings.warn(
-        'This was designed against arrow versions starting with %s'
+        'This was designed against Arrow versions starting with %s'
         ' but you have %s' %
         (TARGET_VERSION, rarrow.__version__))
 

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -28,6 +28,7 @@ def _rarrow_ptr(ptr):
     else:
         return float(ptr_value)
 
+
 def _pyarrow_ptr(ptr):
     return int(ffi.cast("uintptr_t", ptr))
 

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -20,6 +20,7 @@ if not _rarrow_has_c_api:
 # bit64::integer64(), or string, all of which prevent possible
 # problems with the previous versions which required a double().
 _use_r_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
+
 def _rarrow_ptr(ptr):
     ptr_value = int(ffi.cast("uintptr_t", ptr))
     return str(ptr_value) if _use_r_ptr_string else float(ptr_value)

--- a/rpy2_arrow/pyarrow_rarrow.py
+++ b/rpy2_arrow/pyarrow_rarrow.py
@@ -18,15 +18,18 @@ if not rarrow.__version__.startswith(TARGET_VERSION):
 # In arrow >= 7.0.0, pointers can be passed as externalptr,
 # bit64::integer64(), or string, all of which prevent possible
 # problems with the previous versions which required a double().
-_use_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
+_use_r_ptr_string = rinterface.evalr('packageVersion("arrow") >= "6.0.1.9000"')[0]
+def _rarrow_ptr(ptr):
+    global _use_r_ptr_string
+    ptr_value = int(ffi.cast("uintptr_t", ptr))
 
-def _rarrow_ptr(ptr_value):
-    global _use_ptr_string
-
-    if _use_ptr_string:
+    if _use_r_ptr_string:
         return str(ptr_value)
     else:
         return float(ptr_value)
+
+def _pyarrow_ptr(ptr):
+    return int(ffi.cast("uintptr_t", ptr))
 
 
 def pyarrow_to_r_array(
@@ -39,12 +42,10 @@ def pyarrow_to_r_array(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
     array_ptr = ffi.new("struct ArrowArray*")
-    array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
     
-    obj._export_to_c(array_ptr_value, schema_ptr_value)
-    return rarrow.Array["import_from_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
+    return rarrow.Array["import_from_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_array(
@@ -55,12 +56,10 @@ def rarrow_to_py_array(
     This is sharing the C/C++ object between the two languages.
     """
     array_ptr = ffi.new("struct ArrowArray*")
-    array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
-    obj["export_to_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
-    return pyarrow.lib.Array._import_from_c(array_ptr_value, schema_ptr_value)
+    obj["export_to_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    return pyarrow.lib.Array._import_from_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
 
 
 def pyarrow_to_r_recordbatch(
@@ -73,12 +72,10 @@ def pyarrow_to_r_recordbatch(
     rpy2. By default it will be an `rpy2.robjects.Environment`.
     """
     array_ptr = ffi.new("struct ArrowArray*")
-    array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
-    obj._export_to_c(array_ptr_value, schema_ptr_value)
-    return rarrow.RecordBatch["import_from_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
+    return rarrow.RecordBatch["import_from_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_recordbatch(
@@ -89,12 +86,10 @@ def rarrow_to_py_recordbatch(
     This is sharing the C/C++ object between the two languages.
     """
     array_ptr = ffi.new("struct ArrowArray*")
-    array_ptr_value = int(ffi.cast("uintptr_t", array_ptr))
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
 
-    obj["export_to_c"](_rarrow_ptr(array_ptr_value), _rarrow_ptr(schema_ptr_value))
-    return pyarrow.lib.RecordBatch._import_from_c(array_ptr_value, schema_ptr_value)
+    obj["export_to_c"](_rarrow_ptr(array_ptr), _rarrow_ptr(schema_ptr))
+    return pyarrow.lib.RecordBatch._import_from_c(_pyarrow_ptr(array_ptr), _pyarrow_ptr(schema_ptr))
 
 
 def pyarrow_to_r_recordbatchreader(
@@ -108,9 +103,8 @@ def pyarrow_to_r_recordbatchreader(
     """
 
     stream_ptr = ffi.new("struct ArrowArrayStream*")
-    stream_ptr_value = int(ffi.cast("uintptr_t", stream_ptr))
-    obj._export_to_c(stream_ptr_value)
-    return rarrow.RecordBatchReader["import_from_c"](_rarrow_ptr(stream_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(stream_ptr))
+    return rarrow.RecordBatchReader["import_from_c"](_rarrow_ptr(stream_ptr))
 
 
 def rarrow_to_py_recordbatchreader(
@@ -124,9 +118,8 @@ def rarrow_to_py_recordbatchreader(
     """
 
     stream_ptr = ffi.new("struct ArrowArrayStream*")
-    stream_ptr_value = int(ffi.cast("uintptr_t", stream_ptr))
-    obj["export_to_c"](_rarrow_ptr(stream_ptr_value))
-    return pyarrow.lib.RecordBatchReader._import_from_c(stream_ptr_value)
+    obj["export_to_c"](_rarrow_ptr(stream_ptr))
+    return pyarrow.lib.RecordBatchReader._import_from_c(_pyarrow_ptr(stream_ptr))
 
 
 def pyarrow_to_r_chunkedarray(
@@ -158,9 +151,8 @@ def pyarrow_to_r_datatype(
         obj: 'pyarrow.lib.DataType'
 ):
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj._export_to_c(schema_ptr_value)
-    return rarrow.DataType["import_from_c"](_rarrow_ptr(schema_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(schema_ptr))
+    return rarrow.DataType["import_from_c"](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_datatype(
@@ -171,18 +163,16 @@ def rarrow_to_py_datatype(
     This is sharing the C/C++ object between the two languages.
     """
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
-    return pyarrow.lib.DataType._import_from_c(int(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    return pyarrow.lib.DataType._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
 def pyarrow_to_r_field(
         obj: 'pyarrow.lib.Field'
 ):
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj._export_to_c(schema_ptr_value)
-    return rarrow.Field["import_from_c"](_rarrow_ptr(schema_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(schema_ptr))
+    return rarrow.Field["import_from_c"](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_field(
@@ -194,9 +184,8 @@ def rarrow_to_py_field(
     """
 
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
-    return pyarrow.lib.Field._import_from_c(int(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    return pyarrow.lib.Field._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
 def pyarrow_to_r_table(
@@ -259,9 +248,8 @@ def pyarrow_to_r_schema(
     """
 
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj._export_to_c(schema_ptr_value)
-    return rarrow.Schema["import_from_c"](_rarrow_ptr(schema_ptr_value))
+    obj._export_to_c(_pyarrow_ptr(schema_ptr))
+    return rarrow.Schema["import_from_c"](_rarrow_ptr(schema_ptr))
 
 
 def rarrow_to_py_schema(
@@ -275,9 +263,8 @@ def rarrow_to_py_schema(
     """
 
     schema_ptr = ffi.new("struct ArrowSchema*")
-    schema_ptr_value = int(ffi.cast("uintptr_t", schema_ptr))
-    obj["export_to_c"](_rarrow_ptr(schema_ptr_value))
-    return pyarrow.lib.Schema._import_from_c(int(schema_ptr_value))
+    obj["export_to_c"](_rarrow_ptr(schema_ptr))
+    return pyarrow.lib.Schema._import_from_c(_pyarrow_ptr(schema_ptr))
 
 
 converter = conversion.Converter('default arrow conversion',

--- a/rpy2_arrow/tests.py
+++ b/rpy2_arrow/tests.py
@@ -83,15 +83,15 @@ def test_py2r_RecordBatchReader():
     assert isinstance(r_rbr, rinterface.SexpEnvironment)
 
 
-# def test_r2py_RecordBatchReader():
-#     r_rbr = rinterface.evalr("""
-#     require('arrow')
-#     tb <- arrow::Table$create(a = c(1L, 2L, 3L), b = c(4L, 5L, 6L))
-#     scanner <- Scanner$create(tb)
-#     scanner$ToRecordBatchReader()
-#     """)
-#     py_rbr = pyr.rarrow_to_py_recordbatchreader(r_rbr)
-#     assert isinstance(py_rbr, pyarrow.lib.RecordBatchReader)
+def test_r2py_RecordBatchReader():
+    r_rbr = rinterface.evalr("""
+    require('arrow')
+    tb <- arrow::Table$create(a = c(1L, 2L, 3L), b = c(4L, 5L, 6L))
+    scanner <- Scanner$create(tb)
+    scanner$ToRecordBatchReader()
+    """)
+    py_rbr = pyr.rarrow_to_py_recordbatchreader(r_rbr)
+    assert isinstance(py_rbr, pyarrow.lib.RecordBatchReader)
 
 
 def test_py2r_ChunkedArray():

--- a/rpy2_arrow/tests.py
+++ b/rpy2_arrow/tests.py
@@ -62,12 +62,36 @@ def test_py2r_RecordBatch():
 
 
 def test_r2py_RecordBatch():
-    r_ar = rinterface.evalr("""
+    r_rb = rinterface.evalr("""
     require('arrow')
     arrow::RecordBatch$create(a = c(1L, 2L, 3L), b = c(4L, 5L, 6L))
     """)
-    py_ar = pyr.rarrow_to_py_recordbatch(r_ar)
-    assert isinstance(py_ar, pyarrow.RecordBatch)
+    py_rb = pyr.rarrow_to_py_recordbatch(r_rb)
+    assert isinstance(py_rb, pyarrow.RecordBatch)
+
+
+def test_py2r_RecordBatchReader():
+    dataf = pandas.DataFrame.from_dict(
+        {'a': [1, 2, 3],
+         'b': [4, 5, 6]}
+    )
+    py_tb = pyarrow.table(dataf)
+    py_rbr = pyarrow.lib.RecordBatchReader.from_batches(
+        py_tb.schema, 
+        py_tb.to_batches())
+    r_rbr = pyr.pyarrow_to_r_recordbatchreader(py_rbr)
+    assert isinstance(r_rbr, rinterface.SexpEnvironment)
+
+
+# def test_r2py_RecordBatchReader():
+#     r_rbr = rinterface.evalr("""
+#     require('arrow')
+#     tb <- arrow::Table$create(a = c(1L, 2L, 3L), b = c(4L, 5L, 6L))
+#     scanner <- Scanner$create(tb)
+#     scanner$ToRecordBatchReader()
+#     """)
+#     py_rbr = pyr.rarrow_to_py_recordbatchreader(r_rbr)
+#     assert isinstance(py_rbr, pyarrow.lib.RecordBatchReader)
 
 
 def test_py2r_ChunkedArray():

--- a/rpy2_arrow/tests.py
+++ b/rpy2_arrow/tests.py
@@ -77,7 +77,7 @@ def test_py2r_RecordBatchReader():
     )
     py_tb = pyarrow.table(dataf)
     py_rbr = pyarrow.lib.RecordBatchReader.from_batches(
-        py_tb.schema, 
+        py_tb.schema,
         py_tb.to_batches())
     r_rbr = pyr.pyarrow_to_r_recordbatchreader(py_rbr)
     assert isinstance(r_rbr, rinterface.SexpEnvironment)
@@ -99,7 +99,7 @@ def test_r2py_RecordBatchReader():
     )
     py_tb = pyarrow.table(dataf)
     py_rbr = pyarrow.lib.RecordBatchReader.from_batches(
-        py_tb.schema, 
+        py_tb.schema,
         py_tb.to_batches())
     r_rbr = pyr.pyarrow_to_r_recordbatchreader(py_rbr)
     assert isinstance(r_rbr, rinterface.SexpEnvironment)

--- a/rpy2_arrow/tests.py
+++ b/rpy2_arrow/tests.py
@@ -61,6 +61,15 @@ def test_py2r_RecordBatch():
     assert isinstance(r_rb, rinterface.SexpEnvironment)
 
 
+def test_r2py_RecordBatch():
+    r_ar = rinterface.evalr("""
+    require('arrow')
+    arrow::RecordBatch$create(a = c(1L, 2L, 3L), b = c(4L, 5L, 6L))
+    """)
+    py_ar = pyr.rarrow_to_py_recordbatch(r_ar)
+    assert isinstance(py_ar, pyarrow.RecordBatch)
+
+
 def test_py2r_ChunkedArray():
     py_ca = pyarrow.chunked_array([[1, 2, 3], [4, 5]])
     r_ca = pyr.pyarrow_to_r_chunkedarray(py_ca)


### PR DESCRIPTION
Following the discussion at #2, the way that pointers are allocated has changed in the Arrow R package master branch, with a release (7.0.0) coming soon. In particular, the internal functions `allocate_arrow_*()` and `delete_arrow_*()` now work with external pointers (`EXTPTRSXP`) rather than `uintptr_t` casted to `double` and wrapped in a numeric vector. The unit tests for the import/export interface use `pyarrow.ffi` to allocate and delete the intermediate `struct ArrowArray`/`Schema`/`ArrayStream`...I think it makes sense to do that here, too, and results in a slightly cleaner pattern (because cffi takes care of the deleting with garbage collection).

Happy to take a different approach if needed!

Some references that might be useful when reviewing:

- Unit tests for pyarrow: https://github.com/apache/arrow/blob/master/python/pyarrow/tests/test_cffi.py
- Recent PRs affecting the import/export: https://github.com/apache/arrow/pull/11919, https://github.com/apache/arrow/pull/12011, https://github.com/apache/arrow/pull/12062