### PR TITLE
Support older versions of `rpy2`>=3.3.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "pyarrow",
-    "rpy2>= 3.5"
+    "rpy2 >= 3.4"
 ]
 dynamic = ["version"]
 

--- a/rpy2_arrow/arrow.py
+++ b/rpy2_arrow/arrow.py
@@ -227,7 +227,12 @@ def pyarrow_table_to_r_table(obj: pyarrow.lib.Table):
     # `res` is a low-level (rinterface-level) rpy2 object. This is an
     # rpy2 robject-level function. Use the conversion.
     res = _pyarrow_table_to_r_table_ri(obj)
-    return conversion.get_conversion().py2rpy(res)
+    converter = (
+        conversion.get_conversion()  # rpy2 >=3.5.2
+        if hasattr(conversion, 'get_conversion') else
+        conversion.converter  # rpy2 <3.5.2
+    )
+    return converter.py2rpy(res)
 
 
 def rarrow_to_py_table(


### PR DESCRIPTION
Hi @lgautier ,

I have unfortunately been having many issues with the `rpy2` 3.5.x release series, and haven't had much success getting any of these versions working reliably in our stack. I did still want to migrate to `rpy2-arrow` from our custom implementation, since our version (though slightly faster) requires compilation against specific versions of arrow (which makes distribution annoying). As such, please accept this patch to add support for older versions of `rpy2` (we have been having no issues with 3.4.5). I've limited this support arbitrarily to `rpy2` >=3.3 since I doubt anyone will want to use anything older, and did want to provide some lower-bound.

(Note: The current bound in pyproject.toml is >=3.5, but in actual fact you currently require >=3.5.2 due to the threading changes).