### PR TITLE
Use Converter.context for compatibility with rpy2.3.5.9.

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -43,4 +43,4 @@ jobs:
       with:
         user: __token__
         password: ${{ secrets.PYPI_API_TOKEN }}
-	packages_dir: dist
+        packages_dir: dist

--- a/rpy2_arrow/tests_r6b.py
+++ b/rpy2_arrow/tests_r6b.py
@@ -24,12 +24,12 @@ def test_rpy2py_arrays(pyarrow_constructor, pyr_py2r):
     # TODO: bug in rpy2's layering of conversion rules?
     # with conversion.local_converter(
     #         ro.default_converter + r6b_ar.converter
-    # ) as cv:
+    # ).context() as cv:
     env_map = (ro.conversion
                .converter.rpy2py_nc_name[rinterface.SexpEnvironment])
     with conversion.NameClassMapContext(
             env_map,
             r6b_ar.converter.rpy2py_nc_name[rinterface.SexpEnvironment]._map
-    ):
+    ).context():
         r6_ar = pyr_py2r(py_ar)
         assert isinstance(r6_ar, r6b.R6)


### PR DESCRIPTION
Issue #8 