### PR TITLE
Remove workaround which is no longer needed

### DIFF
--- a/doc/notebooks/faster-rpy2-conversion.rst
+++ b/doc/notebooks/faster-rpy2-conversion.rst
@@ -176,12 +176,11 @@ and R. The package :mod:`rpy2_arrow` has a converter to just do that.
 .. ipython::
 
     In [2]: tbl = pyarrow.lib.Table.from_pandas(pd_dataf)
-       ...: pyra_conv = pyra.converter  # work around `%%R` limitations. 
 
 .. ipython::
 
     In [2]: %%time
-       ...: %%R -i tbl -c pyra_conv
+       ...: %%R -i tbl -c pyra.converter
        ...: print(head(tbl))
        ...: rm(tbl)
 


### PR DESCRIPTION
Since https://github.com/rpy2/rpy2/pull/936 this workaround is no longer needed